### PR TITLE
Fix duplicate user input in OpenAI requests

### DIFF
--- a/src/controllers/voice.js
+++ b/src/controllers/voice.js
@@ -75,7 +75,7 @@ class VoiceController {
             const conversationHistory = conversationManager.getConversationHistory(CallSid);
             
             // Generate AI response using OpenAI
-            const aiResult = await openaiService.generatePhoneResponse(conversationHistory, SpeechResult);
+            const aiResult = await openaiService.generatePhoneResponse(conversationHistory);
             
             // Update conversation context based on AI analysis
             if (aiResult.analysis) {

--- a/src/services/openai.js
+++ b/src/services/openai.js
@@ -175,16 +175,10 @@ class OpenAIService {
     /**
      * Generate a phone-optimized response
      */
-    async generatePhoneResponse(conversationHistory, userInput) {
+    async generatePhoneResponse(conversationHistory) {
         try {
-            // Add the latest user input to conversation
-            const messages = [
-                ...conversationHistory,
-                {
-                    role: 'user',
-                    content: userInput
-                }
-            ];
+            // conversationHistory already contains the latest user input
+            const messages = [...conversationHistory];
 
             // Generate AI response
             const result = await this.generateResponse(messages);
@@ -201,8 +195,7 @@ class OpenAIService {
 
         } catch (error) {
             logger.error('Failed to generate phone response', {
-                error: error.message,
-                userInput: userInput.substring(0, 100)
+                error: error.message
             });
 
             // Fallback response


### PR DESCRIPTION
## Summary
- avoid sending the last user input twice when generating a phone response
- update `generatePhoneResponse` call site in voice controller

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e7394644832780ad98388fe0dec3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the conversation handling so that the latest user input is expected to be included in the conversation history, streamlining how responses are generated.
  * Simplified error logging to remove references to user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->